### PR TITLE
feat(codegen): namespace-scoped type naming via --namespace-prefixes

### DIFF
--- a/cmd/soap/internal/gen/command.go
+++ b/cmd/soap/internal/gen/command.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,12 +24,14 @@ func NewCommand() *cobra.Command {
 	_ = cmd.MarkFlagRequired("dir")
 	packageName := cmd.Flags().StringP("package", "p", "", "Go package name (required)")
 	generateClient := cmd.Flags().Bool("client", false, "generate SOAP client code")
+	nsPrefixesFile := cmd.Flags().String("namespace-prefixes", "", "JSON file mapping namespace URIs to short prefixes for type names")
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return run(config{
 			inputFile:      *inputFile,
 			outputDir:      *outputDir,
 			packageName:    *packageName,
 			generateClient: *generateClient,
+			nsPrefixesFile: *nsPrefixesFile,
 		})
 	}
 	return cmd
@@ -39,12 +42,26 @@ type config struct {
 	outputDir      string
 	packageName    string
 	generateClient bool
+	nsPrefixesFile string
 }
 
 func run(cfg config) error {
 	if cfg.packageName == "" {
 		cfg.packageName = filepath.Base(cfg.outputDir)
 	}
+
+	// Load namespace prefixes if provided
+	var nsPrefixes map[string]string
+	if cfg.nsPrefixesFile != "" {
+		data, err := os.ReadFile(cfg.nsPrefixesFile)
+		if err != nil {
+			return fmt.Errorf("failed to read namespace prefixes file: %w", err)
+		}
+		if err := json.Unmarshal(data, &nsPrefixes); err != nil {
+			return fmt.Errorf("failed to parse namespace prefixes file: %w", err)
+		}
+	}
+
 	// Parse the WSDL file
 	defs, err := wsdl.ParseFromFile(cfg.inputFile)
 	if err != nil {
@@ -58,8 +75,9 @@ func run(cfg config) error {
 
 	// Create generator with configuration
 	generator := soapgen.NewGenerator(defs, soapgen.Config{
-		PackageName:    cfg.packageName,
-		GenerateClient: cfg.generateClient,
+		PackageName:       cfg.packageName,
+		GenerateClient:    cfg.generateClient,
+		NamespacePrefixes: nsPrefixes,
 	})
 
 	// Generate the code

--- a/internal/soapgen/client_binding_detection.go
+++ b/internal/soapgen/client_binding_detection.go
@@ -59,6 +59,14 @@ func (g *Generator) getBindingStyle() BindingStyle {
 func (g *Generator) getConsistentTypeName(xmlElementName string, bindingStyle BindingStyle) string {
 	baseName := toGoName(xmlElementName)
 
+	// Apply namespace prefix if scoping is enabled.
+	// Operation message elements belong to the WSDL's target namespace.
+	if g.namespaceScopingEnabled() && g.definitions.TargetNamespace != "" {
+		if prefix := g.nsPrefix(g.definitions.TargetNamespace); prefix != "" {
+			baseName = prefix + "_" + baseName
+		}
+	}
+
 	// Use the same logic as type generation for consistency
 	if g.shouldUseWrapperForElement(xmlElementName, bindingStyle) {
 		return baseName + "Wrapper"

--- a/internal/soapgen/context.go
+++ b/internal/soapgen/context.go
@@ -218,6 +218,53 @@ func (ctx *SchemaContext) resolveComplexType(typeName string) *xsd.ComplexType {
 	return ctx.complexTypes[typeName]
 }
 
+// resolveNsScopedGoName resolves a prefixed XSD type reference (e.g., "ns3:FlexAttr")
+// to a namespace-scoped Go type name (e.g., "Core_FlexAttr").
+// Returns the plain Go name if namespace scoping is not enabled.
+func (ctx *SchemaContext) resolveNsScopedGoName(prefixedType string) string {
+	localName := extractLocalName(prefixedType)
+	goName := toGoName(localName)
+
+	if ctx.generator == nil || !ctx.generator.namespaceScopingEnabled() {
+		return goName
+	}
+
+	colonIdx := strings.LastIndex(prefixedType, ":")
+	if colonIdx == -1 {
+		// No prefix — type is in the current schema's namespace
+		return ctx.generator.nsPrefixedName(ctx.schema.TargetNamespace, goName)
+	}
+
+	prefix := prefixedType[:colonIdx]
+	nsMap := ctx.schema.NamespacePrefixMap()
+	nsURI := nsMap[prefix]
+	if nsURI == "" {
+		// Unknown prefix, use current schema's namespace
+		return ctx.generator.nsPrefixedName(ctx.schema.TargetNamespace, goName)
+	}
+
+	return ctx.generator.nsPrefixedName(nsURI, goName)
+}
+
+// currentNsPrefix returns the short namespace prefix for the current schema,
+// or "" if namespace scoping is not enabled.
+func (ctx *SchemaContext) currentNsPrefix() string {
+	if ctx.generator == nil {
+		return ""
+	}
+	return ctx.generator.nsPrefix(ctx.schema.TargetNamespace)
+}
+
+// scopedGoTypeName returns a namespace-prefixed Go type name for a type
+// declared in the current schema.
+func (ctx *SchemaContext) scopedGoTypeName(xmlName string) string {
+	goName := toGoName(xmlName)
+	if ctx.generator == nil {
+		return goName
+	}
+	return ctx.generator.nsPrefixedName(ctx.schema.TargetNamespace, goName)
+}
+
 // getInlineEnumTypeName returns the type name for an inline enum if it exists
 func (ctx *SchemaContext) getInlineEnumTypeName(parentName, fieldName string) string {
 	typeName := toGoName(parentName) + "_" + toGoName(fieldName)

--- a/internal/soapgen/field_generators.go
+++ b/internal/soapgen/field_generators.go
@@ -158,7 +158,7 @@ func generateStructFieldWithInlineTypesAndContextAndParentAndFieldRegistryIntern
 		goType = convertToQualifiedType(rawType, g)
 		// Handle complex type references - use the Go type name for complex types only
 		if complexType := ctx.resolveComplexType(element.Type); complexType != nil {
-			goType = toGoName(extractLocalName(element.Type))
+			goType = ctx.resolveNsScopedGoName(element.Type)
 		}
 	} else if element.SimpleType != nil {
 		// Check for inline enum type first
@@ -186,15 +186,22 @@ func generateStructFieldWithInlineTypesAndContextAndParentAndFieldRegistryIntern
 				// We need to find the actual generated type name in ctx.anonymousTypes
 				// Try the direct naming first
 				inlineTypeName := toGoName(parentElementName) + "_" + toGoName(element.Name)
+				// Apply namespace prefix if scoping is enabled
+				if prefix := ctx.currentNsPrefix(); prefix != "" {
+					inlineTypeName = prefix + "_" + inlineTypeName
+				}
 				if ctx.anonymousTypes[inlineTypeName] {
 					goType = inlineTypeName
 				} else {
 					// If not found, try with the parent name as-is (for nested types)
 					altInlineTypeName := parentElementName + "_" + toGoName(element.Name)
+					if prefix := ctx.currentNsPrefix(); prefix != "" {
+						altInlineTypeName = prefix + "_" + altInlineTypeName
+					}
 					if ctx.anonymousTypes[altInlineTypeName] {
 						goType = altInlineTypeName
 					} else {
-						// DEBUG: Print available types for debugging
+						// Fallback to RawXML for unresolvable inline types
 						goType = "RawXML"
 					}
 				}

--- a/internal/soapgen/generator.go
+++ b/internal/soapgen/generator.go
@@ -10,15 +10,17 @@ import (
 
 // Config holds configuration for code generation
 type Config struct {
-	PackageName    string
-	GenerateClient bool // Whether to generate SOAP client code
+	PackageName       string
+	GenerateClient    bool              // Whether to generate SOAP client code
+	NamespacePrefixes map[string]string  // Namespace URI → short prefix for type names
 }
 
 // Generator generates Go code from WSDL definitions
 type Generator struct {
-	definitions *wsdl.Definitions
-	config      Config
-	files       []*codegen.File
+	definitions   *wsdl.Definitions
+	config        Config
+	files         []*codegen.File
+	rawXMLEmitted bool // tracks whether RawXML type has been emitted
 }
 
 // NewGenerator creates a new Generator with the given WSDL definitions and config
@@ -28,6 +30,29 @@ func NewGenerator(definitions *wsdl.Definitions, config Config) *Generator {
 		config:      config,
 		files:       make([]*codegen.File, 0),
 	}
+}
+
+// namespaceScopingEnabled returns true if namespace-scoped type naming is active.
+func (g *Generator) namespaceScopingEnabled() bool {
+	return len(g.config.NamespacePrefixes) > 0
+}
+
+// nsPrefix returns the short prefix for a namespace URI, or "" if not configured.
+func (g *Generator) nsPrefix(namespaceURI string) string {
+	return g.config.NamespacePrefixes[namespaceURI]
+}
+
+// nsPrefixedName returns a namespace-scoped Go type name (e.g., "CBE_FlexAttr").
+// If namespace scoping is not enabled or the namespace has no prefix, returns the plain name.
+func (g *Generator) nsPrefixedName(namespaceURI, goName string) string {
+	if !g.namespaceScopingEnabled() {
+		return goName
+	}
+	prefix := g.nsPrefix(namespaceURI)
+	if prefix == "" {
+		return goName
+	}
+	return prefix + "_" + goName
 }
 
 // Generate generates Go code files from the WSDL definitions
@@ -88,11 +113,12 @@ func (g *Generator) generateTypesFile(schema *xsd.Schema, packageName, filename 
 	file.P("package ", packageName)
 	file.P()
 
-	// Generate RawXML type definition if needed
-	if needsRawXML(schema) {
+	// Generate RawXML type definition if needed (only once per package)
+	if needsRawXML(schema) && !g.rawXMLEmitted {
 		file.P("// RawXML captures raw XML content for untyped elements.")
 		file.P("type RawXML []byte")
 		file.P()
+		g.rawXMLEmitted = true
 	}
 
 	// Separate data types from message wrapper types

--- a/internal/soapgen/inline.go
+++ b/internal/soapgen/inline.go
@@ -84,6 +84,10 @@ func generateInlineTypesFromElement(
 			if field.ComplexType != nil {
 				// Generate inline complex type using Outer_Inner naming
 				typeName := registry.generateTypeName(element.Name, field.Name)
+				// Apply namespace prefix if scoping is enabled
+				if prefix := ctx.currentNsPrefix(); prefix != "" {
+					typeName = prefix + "_" + typeName
+				}
 				generateInlineComplexTypeStruct(g, typeName, field.ComplexType, ctx)
 				generated = true
 
@@ -116,6 +120,10 @@ func generateInlineTypesFromComplexType(
 			if field.ComplexType != nil {
 				// Generate inline complex type using Outer_Inner naming
 				typeName := registry.generateTypeName(parentName, field.Name)
+				// Apply namespace prefix if scoping is enabled
+				if prefix := ctx.currentNsPrefix(); prefix != "" {
+					typeName = prefix + "_" + typeName
+				}
 				generateInlineComplexTypeStruct(g, typeName, field.ComplexType, ctx)
 				generated = true
 

--- a/internal/soapgen/namespace_scoping_test.go
+++ b/internal/soapgen/namespace_scoping_test.go
@@ -1,0 +1,166 @@
+package soapgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/way-platform/soap-go/xsd"
+)
+
+func TestNsPrefixedName(t *testing.T) {
+	t.Parallel()
+
+	g := NewGenerator(nil, Config{
+		NamespacePrefixes: map[string]string{
+			"http://example.com/core/v1":    "Core",
+			"http://example.com/billing/v1": "CB",
+		},
+	})
+
+	tests := []struct {
+		ns   string
+		name string
+		want string
+	}{
+		{"http://example.com/core/v1", "FlexAttr", "Core_FlexAttr"},
+		{"http://example.com/billing/v1", "Invoice", "CB_Invoice"},
+		{"http://example.com/unknown/v1", "Foo", "Foo"},   // unmapped namespace
+		{"", "Bar", "Bar"},                                  // empty namespace
+	}
+
+	for _, tt := range tests {
+		got := g.nsPrefixedName(tt.ns, tt.name)
+		if got != tt.want {
+			t.Errorf("nsPrefixedName(%q, %q) = %q, want %q", tt.ns, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestNsPrefixedName_Disabled(t *testing.T) {
+	t.Parallel()
+
+	g := NewGenerator(nil, Config{})
+
+	got := g.nsPrefixedName("http://example.com/core/v1", "FlexAttr")
+	if got != "FlexAttr" {
+		t.Errorf("expected plain name when scoping disabled, got %q", got)
+	}
+}
+
+func TestNamespaceScopingEnabled(t *testing.T) {
+	t.Parallel()
+
+	g1 := NewGenerator(nil, Config{})
+	if g1.namespaceScopingEnabled() {
+		t.Error("expected false when no prefixes configured")
+	}
+
+	g2 := NewGenerator(nil, Config{
+		NamespacePrefixes: map[string]string{"http://example.com": "EX"},
+	})
+	if !g2.namespaceScopingEnabled() {
+		t.Error("expected true when prefixes configured")
+	}
+}
+
+func TestResolveNsScopedGoName(t *testing.T) {
+	t.Parallel()
+
+	schema := &xsd.Schema{
+		TargetNamespace: "http://example.com/service/v1",
+	}
+	// ExtraAttrs would normally be populated by XML parsing; not needed for these tests
+	// since we're testing the generator/context methods directly
+
+	g := NewGenerator(nil, Config{
+		NamespacePrefixes: map[string]string{
+			"http://example.com/service/v1": "SVC",
+			"http://example.com/core/v1":    "Core",
+		},
+	})
+
+	ctx := newSchemaContext(schema, g)
+
+	// Test scopedGoTypeName — for types declared in the current schema
+	got := ctx.scopedGoTypeName("ProductOrder")
+	if got != "SVC_ProductOrder" {
+		t.Errorf("scopedGoTypeName = %q, want SVC_ProductOrder", got)
+	}
+
+	// Test currentNsPrefix
+	prefix := ctx.currentNsPrefix()
+	if prefix != "SVC" {
+		t.Errorf("currentNsPrefix = %q, want SVC", prefix)
+	}
+}
+
+func TestResolveNsScopedGoName_NoScoping(t *testing.T) {
+	t.Parallel()
+
+	schema := &xsd.Schema{
+		TargetNamespace: "http://example.com/service/v1",
+	}
+
+	g := NewGenerator(nil, Config{})
+	ctx := newSchemaContext(schema, g)
+
+	got := ctx.scopedGoTypeName("ProductOrder")
+	if got != "ProductOrder" {
+		t.Errorf("expected plain name without scoping, got %q", got)
+	}
+
+	got = ctx.resolveNsScopedGoName("ProductOrder")
+	if got != "ProductOrder" {
+		t.Errorf("expected plain name without scoping, got %q", got)
+	}
+}
+
+func TestMapXSDTypeToGoWithContext_NamespaceScoping(t *testing.T) {
+	t.Parallel()
+
+	// Create a schema with a complexType and xmlns declarations
+	schemaXML := `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com/service/v1"
+           xmlns:core="http://example.com/core/v1"
+           targetNamespace="http://example.com/service/v1">
+  <xs:import namespace="http://example.com/core/v1"/>
+  <xs:complexType name="MyType">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+
+	schema, err := xsd.Parse(strings.NewReader(schemaXML))
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	g := NewGenerator(nil, Config{
+		NamespacePrefixes: map[string]string{
+			"http://example.com/service/v1": "SVC",
+			"http://example.com/core/v1":    "Core",
+		},
+	})
+
+	ctx := newSchemaContext(schema, g)
+
+	// Local type resolution (tns:MyType or just MyType)
+	got := mapXSDTypeToGoWithContext("tns:MyType", ctx)
+	if got != "SVC_MyType" {
+		t.Errorf("tns:MyType resolved to %q, want SVC_MyType", got)
+	}
+
+	// Cross-namespace type resolution (core:SomeType — not in this schema)
+	got = mapXSDTypeToGoWithContext("core:SomeType", ctx)
+	if got != "Core_SomeType" {
+		t.Errorf("core:SomeType resolved to %q, want Core_SomeType", got)
+	}
+
+	// XSD builtins should NOT be prefixed
+	got = mapXSDTypeToGoWithContext("xs:string", ctx)
+	if strings.Contains(got, "_") {
+		t.Errorf("xs:string should not be namespace-prefixed, got %q", got)
+	}
+}

--- a/internal/soapgen/struct_generators.go
+++ b/internal/soapgen/struct_generators.go
@@ -85,7 +85,7 @@ func generateInlineComplexTypeStruct(
 
 // generateStructFromElement generates a Go struct from an XSD element
 func generateStructFromElement(g *codegen.File, element *xsd.Element, ctx *SchemaContext, _ *TypeRegistry) {
-	structName := toGoName(element.Name)
+	structName := ctx.scopedGoTypeName(element.Name)
 	generateStandardStructWithName(g, element, ctx, structName)
 }
 
@@ -97,7 +97,7 @@ func generateStructFromElementWithWrapper(
 	_ *TypeRegistry,
 ) {
 	// Generate wrapper-style name
-	structName := toGoName(element.Name) + "Wrapper"
+	structName := ctx.scopedGoTypeName(element.Name) + "Wrapper"
 	generateStandardStructWithName(g, element, ctx, structName)
 }
 
@@ -255,7 +255,7 @@ func generateStandardStructWithName(g *codegen.File, element *xsd.Element, ctx *
 
 // generateStructFromComplexType generates a Go struct from a named complex type
 func generateStructFromComplexType(g *codegen.File, complexType *xsd.ComplexType, ctx *SchemaContext) {
-	structName := toGoName(complexType.Name)
+	structName := ctx.scopedGoTypeName(complexType.Name)
 
 	// Add comment
 	g.P("// ", structName, " represents the ", complexType.Name, " complex type")

--- a/internal/soapgen/type_generators.go
+++ b/internal/soapgen/type_generators.go
@@ -28,14 +28,14 @@ func generateSimpleTypeConstants(g *codegen.File, ctx *SchemaContext) {
 	for _, name := range names {
 		simpleType := ctx.simpleTypes[name]
 		if simpleType.Restriction != nil && len(simpleType.Restriction.Enumerations) > 0 {
-			generateEnumType(g, simpleType)
+			generateEnumType(g, simpleType, ctx)
 		}
 	}
 }
 
 // generateEnumType generates a Go enum type from an XSD simple type with enumerations
-func generateEnumType(g *codegen.File, simpleType *xsd.SimpleType) {
-	typeName := toGoName(simpleType.Name)
+func generateEnumType(g *codegen.File, simpleType *xsd.SimpleType, ctx *SchemaContext) {
+	typeName := ctx.scopedGoTypeName(simpleType.Name)
 
 	// Generate the enum type definition
 	g.P("// ", typeName, " represents an enumeration type")

--- a/internal/soapgen/types.go
+++ b/internal/soapgen/types.go
@@ -54,19 +54,32 @@ func mapXSDTypeToGoWithContext(xsdType string, ctx *SchemaContext) string {
 		if simpleType.Restriction != nil && simpleType.Restriction.Base != "" {
 			// If it has enumerations, keep it as a custom type (enum)
 			if len(simpleType.Restriction.Enumerations) > 0 {
-				return toGoName(extractLocalName(xsdType))
+				return ctx.resolveNsScopedGoName(xsdType)
 			}
 			// Otherwise, resolve to the base type (for simple restrictions)
 			return mapXSDTypeToGoWithContext(simpleType.Restriction.Base, ctx)
 		}
 		// If no restriction, treat as the simple type name
-		return toGoName(extractLocalName(xsdType))
+		return ctx.resolveNsScopedGoName(xsdType)
 	}
 
 	// Then try to resolve as a complex type in the schema
 	if complexType := ctx.resolveComplexType(xsdType); complexType != nil {
 		// For named complex types, generate a Go type name
-		return toGoName(extractLocalName(xsdType))
+		return ctx.resolveNsScopedGoName(xsdType)
+	}
+
+	// When namespace scoping is enabled, any prefixed type reference that wasn't
+	// found in the current schema is a cross-namespace reference.
+	// Skip XSD namespace prefixes (xs:string, xs:int, etc.)
+	if ctx.generator != nil && ctx.generator.namespaceScopingEnabled() {
+		if colonIdx := strings.LastIndex(xsdType, ":"); colonIdx != -1 {
+			prefix := xsdType[:colonIdx]
+			nsMap := ctx.schema.NamespacePrefixMap()
+			if nsURI := nsMap[prefix]; nsURI != "" && nsURI != "http://www.w3.org/2001/XMLSchema" {
+				return ctx.resolveNsScopedGoName(xsdType)
+			}
+		}
 	}
 
 	// Check if this is a custom type (contains namespace prefix or ends with "Type")

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -5,6 +5,19 @@ import (
 	"io"
 )
 
+// NamespacePrefixMap returns a mapping of XML namespace prefixes to URIs
+// from the xmlns:* declarations on the schema element.
+// For example, xmlns:ns3="http://example.com/types" yields {"ns3": "http://example.com/types"}.
+func (s *Schema) NamespacePrefixMap() map[string]string {
+	m := make(map[string]string)
+	for _, attr := range s.ExtraAttrs {
+		if attr.Name.Space == "xmlns" {
+			m[attr.Name.Local] = attr.Value
+		}
+	}
+	return m
+}
+
 // Parse reads an XSD schema from an io.Reader and unmarshals it.
 func Parse(r io.Reader) (*Schema, error) {
 	var schema Schema
@@ -36,10 +49,11 @@ func (s *Schema) ResolveComplexType(typeName string) *ComplexType {
 
 // Schema represents an <xsd:schema> element.
 type Schema struct {
-	XMLName              xml.Name `xml:"schema"`
-	TargetNamespace      string   `xml:"targetNamespace,attr"`
-	ElementFormDefault   string   `xml:"elementFormDefault,attr"`
-	AttributeFormDefault string   `xml:"attributeFormDefault,attr"`
+	XMLName              xml.Name   `xml:"schema"`
+	TargetNamespace      string     `xml:"targetNamespace,attr"`
+	ElementFormDefault   string     `xml:"elementFormDefault,attr"`
+	AttributeFormDefault string     `xml:"attributeFormDefault,attr"`
+	ExtraAttrs           []xml.Attr `xml:",any,attr"` // Captures xmlns:* namespace declarations
 
 	Imports         []Import         `xml:"import"`
 	Includes        []Include        `xml:"include"`

--- a/xsd/xmlns_test.go
+++ b/xsd/xmlns_test.go
@@ -1,0 +1,80 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/way-platform/soap-go/xsd"
+)
+
+func TestSchemaNamespacePrefixMap(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ns1="http://example.com/types/v1"
+           xmlns:ns2="http://example.com/core/v1"
+           xmlns:tns="http://example.com/service/v1"
+           targetNamespace="http://example.com/service/v1"
+           elementFormDefault="qualified">
+  <xs:import namespace="http://example.com/types/v1"/>
+  <xs:import namespace="http://example.com/core/v1"/>
+  <xs:complexType name="Foo">
+    <xs:sequence>
+      <xs:element name="bar" type="ns1:Bar"/>
+      <xs:element name="baz" type="ns2:Baz"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+
+	schema, err := xsd.Parse(strings.NewReader(schemaXML))
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	nsMap := schema.NamespacePrefixMap()
+
+	tests := []struct {
+		prefix string
+		uri    string
+	}{
+		{"xs", "http://www.w3.org/2001/XMLSchema"},
+		{"ns1", "http://example.com/types/v1"},
+		{"ns2", "http://example.com/core/v1"},
+		{"tns", "http://example.com/service/v1"},
+	}
+
+	for _, tt := range tests {
+		got, ok := nsMap[tt.prefix]
+		if !ok {
+			t.Errorf("xmlns:%s not captured", tt.prefix)
+			continue
+		}
+		if got != tt.uri {
+			t.Errorf("xmlns:%s = %q, want %q", tt.prefix, got, tt.uri)
+		}
+	}
+
+	if len(nsMap) != 4 {
+		t.Errorf("expected 4 namespace prefixes, got %d", len(nsMap))
+	}
+}
+
+func TestSchemaNamespacePrefixMap_Empty(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+</xs:schema>`
+
+	schema, err := xsd.Parse(strings.NewReader(schemaXML))
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	nsMap := schema.NamespacePrefixMap()
+	// Should have at least the xs prefix
+	if _, ok := nsMap["xs"]; !ok {
+		t.Error("expected xs prefix to be captured")
+	}
+}


### PR DESCRIPTION
## Problem

When a WSDL contains multiple XML schemas (common in enterprise SOAP services), different schemas can define types with the same name in different namespaces. XSD handles this through namespace scoping, but since soap-go generates all types into a single Go package, these produce compile-time name collisions.

The natural solution would be to generate each namespace into its own Go package. However, XSD namespaces commonly have **circular import dependencies** (namespace A imports types from B, B imports types from A). This is valid in XSD and handled natively by Java/C#, but Go's package system forbids circular imports, making per-namespace packages impossible for most real-world WSDLs.

## Solution

This PR adds a `--namespace-prefixes` flag that accepts a JSON file mapping namespace URIs to short prefixes:

```json
{
  "http://example.com/core/types/v1": "Core",
  "http://example.com/billing/types/v1": "CB",
  "http://example.com/orders/types/v1": "COM"
}
```

When provided, every generated Go type is prefixed with its schema's namespace abbreviation:

```go
// Without --namespace-prefixes (collides if both schemas define ProductOrder):
type ProductOrder struct { ... }

// With --namespace-prefixes:
type COM_ProductOrder struct { ... }
type CBI_ProductOrder struct { ... }
```

### How it works

1. **xmlns capture**: The `Schema` struct now captures `xmlns:*` declarations via an `ExtraAttrs` field, with a `NamespacePrefixMap()` helper to extract the prefix-to-URI mapping.

2. **Type declarations**: When generating struct, enum, and inline anonymous types, the generator prepends the namespace prefix from the user-provided map.

3. **Type references**: When a field references a type from another namespace (e.g., `type="ns3:FlexAttr"`), the generator resolves `ns3` → namespace URI (via xmlns map) → short prefix (via user map) → `Core_FlexAttr`.

4. **XSD builtins excluded**: References to `xs:string`, `xs:int`, etc. are never prefixed — only user-defined types get namespace scoping.

5. **Client code**: Operation wrapper types in the generated client are prefixed using the WSDL's own target namespace.

### What doesn't change

When `--namespace-prefixes` is not provided, behavior is identical to before. All existing tests pass unchanged.

## Why not per-namespace packages?

I explored generating each namespace into its own Go package with proper cross-package imports. The prototype worked for WSDLs without circular namespace dependencies. However, enterprise WSDLs commonly have bidirectional namespace imports (e.g., a "common entities" schema imports from "billing", and "billing" imports from "common entities"). Go's prohibition on circular package imports makes this approach fundamentally incompatible with real-world XSD namespace graphs.

The namespace-prefix approach keeps everything in a single package while eliminating collisions through deterministic, user-controlled naming.

## Usage

```bash
soap gen -i service.wsdl -d output/ -p mypackage --namespace-prefixes prefixes.json
```

The JSON file must map every namespace URI that appears as a `targetNamespace` in the WSDL's schemas. Namespaces not in the map will generate types without a prefix.

## Also included

- Fix: `RawXML` type declaration is now emitted only once per package (was duplicated in multi-schema WSDLs)