### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
 
       - name: Build
         run: mise run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
 
       - name: Build
         run: mise run build
 
       - name: Run Go Semantic Release
-        uses: go-semantic-release/action@v1
+        uses: go-semantic-release/action@2e9dc4247a6004f8377781bef4cb9dad273a741f # v1
         with:
           allow-initial-development-versions: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks (as seen in the trivy-action and kics-github-action compromises)
- Pin every action reference to its resolved commit SHA, keeping the version tag as a trailing comment

## Test plan
- [x] `mise run build` passes locally